### PR TITLE
TableRow: List<Map<String, String>> -> List<Map<String, ?>>

### DIFF
--- a/src/main/java/client/domain/response/chain/TableRow.java
+++ b/src/main/java/client/domain/response/chain/TableRow.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class TableRow {
 
-    private List<Map<String, String>> rows;
+    private List<Map<String, ?>> rows;
 
     private Boolean more;
 
@@ -13,11 +13,11 @@ public class TableRow {
 
     }
 
-    public List<Map<String, String>> getRows() {
+    public List<Map<String, ?>> getRows() {
         return rows;
     }
 
-    public void setRows(List<Map<String, String>> rows) {
+    public void setRows(List<Map<String, ?>> rows) {
         this.rows = rows;
     }
 


### PR DESCRIPTION
### There is an error in the following code:

> EosApiRestClient client = EosApiClientFactory.newInstance("http://mainnet.eoscanada.com/").newRestClient();
        TableRow tableRows = client.getTableRows("eosio", "eosio", "rammarket");
        System.out.println(tableRows);

### The error as follows:

> _client.exception.EosApiException: com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.lang.String out of START_OBJECT token
 at [Source: okhttp3.ResponseBody$BomAwareReader@5c6648b0; line: 1, column: 54] (through reference chain: client.domain.response.chain.TableRow["rows"]->java.util.ArrayList[0]-java.util.LinkedHashMap["base"])_
       at client.impl.EosApiServiceGenerator.executeSync(EosApiServiceGenerator.java:48)
	at client.impl.EosApiRestClientImpl.getTableRows(EosApiRestClientImpl.java:80)
### After: 
![image](https://user-images.githubusercontent.com/2246803/42733854-eebb9b0e-886b-11e8-8af5-f7400794009f.png)

