### PR TITLE
fixed parameters lost for /v1/wallet/list_keys

### DIFF
--- a/src/main/java/client/EosApiRestClient.java
+++ b/src/main/java/client/EosApiRestClient.java
@@ -60,7 +60,7 @@ public interface EosApiRestClient {
 
     List<String> listWallets();
 
-    List<List<String>> listKeys();
+    List<List<String>> listKeys(String walletName, String password);
 
     List<String> getPublicKeys();
 

--- a/src/main/java/client/impl/EosApiRestClientImpl.java
+++ b/src/main/java/client/impl/EosApiRestClientImpl.java
@@ -177,8 +177,9 @@ public class EosApiRestClientImpl implements EosApiRestClient {
     }
 
     @Override
-    public List<List<String>> listKeys(){
-       return EosApiServiceGenerator.executeSync(eosWalletApiService.listKeys());
+    public List<List<String>> listKeys(String walletName, String password){
+        List<String> requestFields = Arrays.asList(walletName, password);
+       return EosApiServiceGenerator.executeSync(eosWalletApiService.listKeys(requestFields));
     }
 
     @Override

--- a/src/main/java/client/impl/EosWalletApiService.java
+++ b/src/main/java/client/impl/EosWalletApiService.java
@@ -32,8 +32,8 @@ public interface EosWalletApiService {
     @GET("/v1/wallet/list_wallets")
     Call<List<String>> listWallets();
 
-    @GET("/v1/wallet/list_keys")
-    Call<List<List<String>>> listKeys();
+    @POST("/v1/wallet/list_keys")
+    Call<List<List<String>>> listKeys(@Body List<String> parameters);
 
     @GET("/v1/wallet/get_public_keys")
     Call<List<String>> getPublicKeys();


### PR DESCRIPTION
api /v1/wallet/list_keys needs some parameters

- walletName
- walletPassword

```
[adyliu@uranus ~]$ cleos --print-request --print-response wallet private_keys
password: REQUEST:
---------------------
POST /v1/wallet/list_keys HTTP/1.0
Host: 127.0.0.1:3000
content-length: 74
Accept: */*
Connection: close

[
  "default",
  "PW5KgHntBk1e6MFK4tyq7qQJYa6L7xj9CnvKi86texVJ-----"
]
---------------------
RESPONSE:
---------------------
[[
    "EOS5khPHTWkWWiQo6NsEQPzvLjgYiAeD3iYZyFLepUpXLjDUoWUvk",
    "5KgWqZj1Z2WaPpdjeiPrKf4auK9FjpsQ1a4PDBUfphb-----"
  ],[
    "EOS6uSDTK4sVGewre2suzcHMgRZKCgjdW4DJDMLukfEwVssPSQu7V",
    "5KTMd5tzu2qzq9KdjLQjwEyVz7zoK5ukyevxyHQZ5f-----"
  ]
]
```