### PR TITLE
Fix issues #20 - JSON parse error with "new_producers" in block

### DIFF
--- a/src/main/java/client/domain/response/chain/Block.java
+++ b/src/main/java/client/domain/response/chain/Block.java
@@ -1,7 +1,9 @@
 package client.domain.response.chain;
 
-import client.domain.response.history.transaction.Transaction;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import client.domain.response.chain.block.NewProducers;
+import client.domain.response.history.transaction.Transaction;
 
 
 public class Block {
@@ -20,7 +22,7 @@ public class Block {
 
     private String scheduleVersion;
 
-    private String[] newProducers;
+    private NewProducers newProducers;
 
     private String producerSignature;
 
@@ -132,12 +134,12 @@ public class Block {
         this.refBlockPrefix = refBlockPrefix;
     }
 
-    public String[] getNewProducers() {
+    public NewProducers getNewProducers() {
         return newProducers;
     }
 
     @JsonProperty("new_producers")
-    public void setNewProducers(String[] newProducers) {
+    public void setNewProducers(NewProducers newProducers) {
         this.newProducers = newProducers;
     }
 

--- a/src/main/java/client/domain/response/chain/block/NewProducers.java
+++ b/src/main/java/client/domain/response/chain/block/NewProducers.java
@@ -1,0 +1,41 @@
+package client.domain.response.chain.block;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class NewProducers {
+	/*
+	  # cleos -u http://mainnet.genereos.io get block 13981050
+	  ......
+	  "new_producers": {
+	    "version": 308,
+	    "producers": [{
+	        "producer_name": "argentinaeos",
+	        "block_signing_key": "EOS7jq4FHrFrtCXxpRQ39dBeDMa5AjM4VaRbqBECkSa5aZnizJzrx"
+	      },{
+	        "producer_name": "bitfinexeos1",
+	        "block_signing_key": "EOS4tkw7LgtURT3dvG3kQ4D1sg3aAtPDymmoatpuFkQMc7wzZdKxc"
+	      }, ......
+	      ......
+	
+	*/
+	
+    private int version;
+
+    private Producer[] producers;
+    
+    public NewProducers()
+    {
+    	
+    }
+    
+    @JsonProperty("version")
+    public void setVersion(int version) {
+        this.version = version;
+    }
+    
+    @JsonProperty("producers")
+    public void setProducers(Producer[] producers) {
+        this.producers = producers;
+    }
+    
+}

--- a/src/main/java/client/domain/response/chain/block/Producer.java
+++ b/src/main/java/client/domain/response/chain/block/Producer.java
@@ -1,0 +1,41 @@
+package client.domain.response.chain.block;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Producer {
+	/*
+	  # cleos -u http://mainnet.genereos.io get block 13981050
+	  ......
+	  "new_producers": {
+	    "version": 308,
+	    "producers": [{
+	        "producer_name": "argentinaeos",
+	        "block_signing_key": "EOS7jq4FHrFrtCXxpRQ39dBeDMa5AjM4VaRbqBECkSa5aZnizJzrx"
+	      },{
+	        "producer_name": "bitfinexeos1",
+	        "block_signing_key": "EOS4tkw7LgtURT3dvG3kQ4D1sg3aAtPDymmoatpuFkQMc7wzZdKxc"
+	      }, ......
+	      ......
+	
+	*/
+	
+    private String producerName;
+
+    private String blockSigningKey;
+    
+    public Producer()
+    {
+    	
+    }
+    
+    @JsonProperty("producer_name")
+    public void setProducerName(String producerName) {
+        this.producerName = producerName;
+    }
+    
+    @JsonProperty("block_signing_key")
+    public void setBlockSigningKey(String blockSigningKey) {
+        this.blockSigningKey = blockSigningKey;
+    }
+    
+}


### PR DESCRIPTION
This PR is fixing issues #20.
Block#13981050 has details with:

`  "new_producers": {
    "version": 308,
    "producers": [{
        "producer_name": "argentinaeos",
        "block_signing_key": "EOS7jq4FHrFrtCXxpRQ39dBeDMa5AjM4VaRbqBECkSa5aZnizJzrx"
      },{
        "producer_name": "bitfinexeos1",
        "block_signing_key": "EOS4tkw7LgtURT3dvG3kQ4D1sg3aAtPDymmoatpuFkQMc7wzZdKxc"
      },{
        "producer_name": "cypherglasss",
        "block_signing_key": "EOS54cMjZnzAHdGgoyutVvZ2AtS79wUYZf8oe39DqLB99772r7MbN"
      },`

This thows:
`client.exception.EosApiException: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of java.lang.String[] out of START_OBJECT token
at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 368] (through reference chain: client.domain.response.chain.Block["new_producers"])
at client.impl.EosApiServiceGenerator.executeSync(EosApiServiceGenerator.java:48)
at client.impl.EosApiRestClientImpl.getBlock(EosApiRestClientImpl.java:53)
at com.bithank.eos.Scanner.main(Scanner.java:59)
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of java.lang.String[] out of START_OBJECT token
at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 368] (through reference chain: client.domain.response.chain.Block["new_producers"])`